### PR TITLE
feat: add scrolling awareness banner

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -23,6 +23,34 @@ body {
   line-height: 1.6;
 }
 
+/* Bandeau de sensibilisation défilant en haut de page */
+.awareness-banner {
+  background: #ffebcc;
+  color: var(--dark-text);
+  padding: 0.3rem 0;
+  overflow: hidden;
+  font-size: 0.9rem;
+}
+
+.awareness-track {
+  display: inline-block;
+  white-space: nowrap;
+  animation: awareness-scroll 25s linear infinite;
+}
+
+.awareness-track span {
+  margin-right: 2rem;
+}
+
+@keyframes awareness-scroll {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
 /* Header navigation */
 header {
   background-color: var(--primary-color);

--- a/d/index.html
+++ b/d/index.html
@@ -7,6 +7,14 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <div class="awareness-banner">
+    <div class="awareness-track">
+      <span>Stop au trafic d'animaux : signalez les pratiques illégales.</span>
+      <span>Hotline maltraitance : 0 800 123 456 (24 /24).</span>
+      <span>Adoptez, n'achetez pas : offrez une seconde chance.</span>
+      <span>Pensez à stériliser et vacciner vos compagnons.</span>
+    </div>
+  </div>
   <header>
     <div class="branding">
       <img src="images/logo.png" alt="Logo Mon Compagnon" class="logo">


### PR DESCRIPTION
## Summary
- add awareness banner atop homepage with hotline and anti-trafficking messages
- style banner with smooth scrolling animation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a04b2520e08328b9d1adea6f53a1cd