### PR TITLE
feat: display album photos with comments side

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -332,28 +332,29 @@ button:hover {
 /* Album photo gallery */
 .album-gallery {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 10px;
   margin-top: 1rem;
 }
 
 .album-gallery img {
-  width: 120px;
-  height: 120px;
-  object-fit: cover;
+  max-width: 200px;
+  max-height: 200px;
+  width: auto;
+  height: auto;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .album-item {
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
+  gap: 10px;
 }
 
 .album-comment {
-  margin-top: 0.5rem;
-  width: 120px;
+  width: 200px;
+  margin-top: 0;
   font-size: 0.8rem;
 }
 


### PR DESCRIPTION
## Summary
- keep album photos' aspect ratio and display them in a vertical list
- place comment fields beside their photos for easier editing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0595604c083289fb085e3a7768927