### PR TITLE
Add adoptable dogs feed with search on home page

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -23,6 +23,14 @@ body {
   line-height: 1.6;
 }
 
+.search-box {
+  display: block;
+  margin: 0 auto 1rem;
+  padding: 0.5rem;
+  max-width: 300px;
+  width: 100%;
+}
+
 /* Thin rotating awareness messages at the very top */
 .awareness-banner {
   background-color: #ffe08a;

--- a/d/index.html
+++ b/d/index.html
@@ -32,6 +32,12 @@
     </div>
   </section>
   <section class="section">
+    <h2 class="section-title">Chiens à adopter</h2>
+    <input type="text" id="search-dog-input" placeholder="Chercher un chien..." class="search-box">
+    <div id="home-dogs-container" class="cards-container"></div>
+    <p id="no-home-dogs-message" style="text-align:center; display:none;">Aucun chien n’est actuellement disponible.</p>
+  </section>
+  <section class="section">
     <h2 class="section-title">Chiens qui ont trouvé un nouveau foyer</h2>
     <div class="gallery-slider">
       <button class="slider-btn prev" aria-label="Précédent">&#10094;</button>

--- a/d/js/app.js
+++ b/d/js/app.js
@@ -422,6 +422,57 @@ function loadDogsPage() {
   }
 }
 
+// Display preview of adoptable dogs on the home page with search
+function loadHomeDogs() {
+  const container = document.getElementById('home-dogs-container');
+  if (!container) return;
+  const searchInput = document.getElementById('search-dog-input');
+  const users = getUsers();
+
+  function render(filter = '') {
+    container.innerHTML = '';
+    let count = 0;
+    users.forEach(user => {
+      if (user.pet) {
+        const text = (user.pet.name + ' ' + user.pet.description).toLowerCase();
+        if (filter && !text.includes(filter)) return;
+        count++;
+        const card = document.createElement('div');
+        card.className = 'card';
+        const img = document.createElement('img');
+        if (user.pet.photos && user.pet.photos.length > 0) {
+          img.src = user.pet.photos[0].data;
+        } else {
+          img.src = 'images/real2.jpg';
+        }
+        img.alt = user.pet.name;
+        card.appendChild(img);
+        const content = document.createElement('div');
+        content.className = 'card-content';
+        const h3 = document.createElement('h3');
+        h3.textContent = user.pet.name;
+        const p = document.createElement('p');
+        p.textContent = user.pet.description;
+        const fund = document.createElement('p');
+        fund.className = 'fund';
+        fund.textContent = 'Cagnotte: ' + user.fund.toFixed(2) + ' €';
+        content.append(h3, p, fund);
+        card.appendChild(content);
+        container.appendChild(card);
+      }
+    });
+    const messageEl = document.getElementById('no-home-dogs-message');
+    if (messageEl) messageEl.style.display = count === 0 ? 'block' : 'none';
+  }
+
+  render();
+  if (searchInput) {
+    searchInput.addEventListener('input', () => {
+      render(searchInput.value.trim().toLowerCase());
+    });
+  }
+}
+
 // Simple slider for the home page gallery
 function initGallerySlider() {
   const slider = document.querySelector('.gallery-slider');
@@ -484,6 +535,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (document.getElementById('dogs-page')) {
     loadDogsPage();
   }
+  loadHomeDogs();
   // Home page slider
   initGallerySlider();
   // Awareness messages banner


### PR DESCRIPTION
## Summary
- Add searchable preview of adoptable dogs to the home page
- Style search bar for consistency
- Load adoptable dogs on page load and allow filtering by name or description

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a059e030148328ace87f4e2eae8704