### PR TITLE
Align home adoption cards horizontally and replace search bar

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -31,6 +31,23 @@ body {
   width: 100%;
 }
 
+.search-button {
+  display: block;
+  margin: 0 auto 1rem;
+  padding: 0.7rem 1.2rem;
+  max-width: 200px;
+  text-align: center;
+  background-color: var(--primary-color);
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+  transition: background-color 0.3s ease;
+}
+
+.search-button:hover {
+  background-color: var(--secondary-color);
+}
+
 /* Thin rotating awareness messages at the very top */
 .awareness-banner {
   background-color: #ffe08a;
@@ -441,6 +458,15 @@ button:hover {
   justify-content: center;
   gap: 20px;
   padding: 1rem;
+}
+
+#home-dogs-container {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+}
+
+#home-dogs-container .card {
+  flex: 0 0 auto;
 }
 
 .card {

--- a/d/index.html
+++ b/d/index.html
@@ -33,7 +33,7 @@
   </section>
   <section class="section">
     <h2 class="section-title">Chiens à adopter</h2>
-    <input type="text" id="search-dog-input" placeholder="Chercher un chien..." class="search-box">
+    <a href="dogs.html" class="search-button">Chercher un chien</a>
     <div id="home-dogs-container" class="cards-container"></div>
     <p id="no-home-dogs-message" style="text-align:center; display:none;">Aucun chien n’est actuellement disponible.</p>
   </section>

--- a/d/js/app.js
+++ b/d/js/app.js
@@ -426,51 +426,38 @@ function loadDogsPage() {
 function loadHomeDogs() {
   const container = document.getElementById('home-dogs-container');
   if (!container) return;
-  const searchInput = document.getElementById('search-dog-input');
   const users = getUsers();
-
-  function render(filter = '') {
-    container.innerHTML = '';
-    let count = 0;
-    users.forEach(user => {
-      if (user.pet) {
-        const text = (user.pet.name + ' ' + user.pet.description).toLowerCase();
-        if (filter && !text.includes(filter)) return;
-        count++;
-        const card = document.createElement('div');
-        card.className = 'card';
-        const img = document.createElement('img');
-        if (user.pet.photos && user.pet.photos.length > 0) {
-          img.src = user.pet.photos[0].data;
-        } else {
-          img.src = 'images/real2.jpg';
-        }
-        img.alt = user.pet.name;
-        card.appendChild(img);
-        const content = document.createElement('div');
-        content.className = 'card-content';
-        const h3 = document.createElement('h3');
-        h3.textContent = user.pet.name;
-        const p = document.createElement('p');
-        p.textContent = user.pet.description;
-        const fund = document.createElement('p');
-        fund.className = 'fund';
-        fund.textContent = 'Cagnotte: ' + user.fund.toFixed(2) + ' €';
-        content.append(h3, p, fund);
-        card.appendChild(content);
-        container.appendChild(card);
+  container.innerHTML = '';
+  let count = 0;
+  users.forEach(user => {
+    if (user.pet) {
+      count++;
+      const card = document.createElement('div');
+      card.className = 'card';
+      const img = document.createElement('img');
+      if (user.pet.photos && user.pet.photos.length > 0) {
+        img.src = user.pet.photos[0].data;
+      } else {
+        img.src = 'images/real2.jpg';
       }
-    });
-    const messageEl = document.getElementById('no-home-dogs-message');
-    if (messageEl) messageEl.style.display = count === 0 ? 'block' : 'none';
-  }
-
-  render();
-  if (searchInput) {
-    searchInput.addEventListener('input', () => {
-      render(searchInput.value.trim().toLowerCase());
-    });
-  }
+      img.alt = user.pet.name;
+      card.appendChild(img);
+      const content = document.createElement('div');
+      content.className = 'card-content';
+      const h3 = document.createElement('h3');
+      h3.textContent = user.pet.name;
+      const p = document.createElement('p');
+      p.textContent = user.pet.description;
+      const fund = document.createElement('p');
+      fund.className = 'fund';
+      fund.textContent = 'Cagnotte: ' + user.fund.toFixed(2) + ' €';
+      content.append(h3, p, fund);
+      card.appendChild(content);
+      container.appendChild(card);
+    }
+  });
+  const messageEl = document.getElementById('no-home-dogs-message');
+  if (messageEl) messageEl.style.display = count === 0 ? 'block' : 'none';
 }
 
 // Simple slider for the home page gallery


### PR DESCRIPTION
## Summary
- Display home page adoption announcements in a horizontal scroll layout
- Replace search bar with button linking to dog search page

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68a05d525ef8832884046cc00f9098ab