### PR TITLE
Allow multiple photo album selection and preview

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -357,7 +357,7 @@ button:hover {
 /* Album photo gallery */
 .album-gallery {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 10px;
   margin-top: 1rem;
 }
@@ -369,12 +369,14 @@ button:hover {
   height: auto;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
 }
 
 .album-item {
   display: flex;
-  align-items: flex-start;
-  gap: 10px;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
 }
 
 .album-comment {

--- a/d/js/app.js
+++ b/d/js/app.js
@@ -355,7 +355,12 @@ function displayAlbum(pet) {
       const img = document.createElement('img');
       img.src = ph.data;
       img.alt = ph.name;
-      wrap.appendChild(img);
+      img.style.cursor = 'pointer';
+      const link = document.createElement('a');
+      link.href = ph.data;
+      link.target = '_blank';
+      link.appendChild(img);
+      wrap.appendChild(link);
       const ta = document.createElement('textarea');
       ta.className = 'album-comment';
       ta.placeholder = 'Ajouter un commentaire';


### PR DESCRIPTION
## Summary
- Improve album gallery layout to support multiple pictures and add pointer cursor
- Wrap album thumbnails with links to open full-size images in new tab for preview

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a06318beec83289d5acc2d99f59c8d