### PR TITLE
feat: require multiple photos in album

### DIFF
--- a/d/dashboard.html
+++ b/d/dashboard.html
@@ -40,7 +40,7 @@
         <textarea id="pet-behavior" placeholder="Décrivez les habitudes et le tempérament" required></textarea>
         <label for="pet-vet">Certificat vétérinaire de santé</label>
         <input type="file" id="pet-vet" accept="application/pdf,image/*">
-        <label for="pet-photos">Photos du chien</label>
+        <label for="pet-photos">Photos du chien (au moins deux)</label>
         <input type="file" id="pet-photos" accept="image/*" multiple>
         <p id="pet-error" style="color:red;"></p>
         <button type="submit">Enregistrer les informations</button>

--- a/d/js/app.js
+++ b/d/js/app.js
@@ -168,6 +168,12 @@ function savePetInfo(user) {
     if (errorEl) errorEl.textContent = 'Veuillez remplir tous les champs concernant votre chien.';
     return;
   }
+  const existingPhotos = (user.pet && user.pet.photos) ? user.pet.photos : [];
+  const totalPhotos = existingPhotos.length + (photoInput.files ? photoInput.files.length : 0);
+  if (totalPhotos < 2) {
+    if (errorEl) errorEl.textContent = 'Veuillez ajouter au moins deux photos de votre chien.';
+    return;
+  }
   // Read files asynchronously and then save
   const readerTasks = [];
   // Vet certificate (single file)
@@ -185,7 +191,7 @@ function savePetInfo(user) {
     readerTasks.push(vetPromise);
   }
   // Photos (multiple)
-  const photos = [];
+  const photos = existingPhotos.slice();
   if (photoInput.files && photoInput.files.length > 0) {
     Array.from(photoInput.files).forEach(file => {
       const p = new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- Ensure dog album includes at least two photos when saving pet info
- Preserve existing photos and inform user of requirement

## Testing
- `npm test --prefix d` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac7e16b88328a8dbb93bf85d049c