### PR TITLE
Refactor inline styles into reusable CSS classes

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -23,6 +23,37 @@ body {
   line-height: 1.6;
 }
 
+/* Utility classes replacing former inline styles */
+.brand-title {
+  font-size: 1.4rem;
+  font-weight: bold;
+}
+
+.error-message {
+  color: red;
+}
+
+.form-note {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.hidden-message {
+  text-align: center;
+  display: none;
+}
+
+.hidden-section {
+  display: none;
+}
+
+.footer {
+  text-align: center;
+  padding: 1rem 0;
+  background: var(--primary-color);
+  color: #fff;
+}
+
 .search-box {
   display: block;
   margin: 0 auto 1rem;

--- a/d/dashboard.html
+++ b/d/dashboard.html
@@ -10,7 +10,7 @@
   <header>
     <div class="branding">
       <img src="images/logo.png" alt="Logo Mon Compagnon" class="logo">
-      <span style="font-size:1.4rem;font-weight:bold;">Mon&nbsp;Compagnon</span>
+        <span class="brand-title">Mon&nbsp;Compagnon</span>
     </div>
     <nav>
       <a href="index.html">Accueil</a>
@@ -42,14 +42,14 @@
         <input type="file" id="pet-vet" accept="application/pdf,image/*">
         <label for="pet-photos">Photos du chien (au moins deux)</label>
         <input type="file" id="pet-photos" accept="image/*" multiple>
-        <p id="pet-error" style="color:red;"></p>
+          <p id="pet-error" class="error-message"></p>
         <button type="submit">Enregistrer les informations</button>
       </form>
     </section>
     <section class="pet-info" id="pet-info">
       <!-- Pet info preview will be inserted here -->
     </section>
-    <section id="photo-album" style="display:none;">
+      <section id="photo-album" class="hidden-section">
       <h3>Album photo de votre chien</h3>
       <input type="file" id="album-input" accept="image/*" multiple>
       <div id="album-gallery" class="album-gallery"></div>

--- a/d/dogs.html
+++ b/d/dogs.html
@@ -10,7 +10,7 @@
   <header>
     <div class="branding">
       <img src="images/logo.png" alt="Logo Mon Compagnon" class="logo">
-      <span style="font-size:1.4rem;font-weight:bold;">Mon&nbsp;Compagnon</span>
+        <span class="brand-title">Mon&nbsp;Compagnon</span>
     </div>
     <nav>
       <a href="index.html">Accueil</a>
@@ -24,7 +24,7 @@
     <div id="dogs-container" class="cards-container">
       <!-- Dog cards will be appended here -->
     </div>
-    <p id="no-dogs-message" style="text-align:center; display:none;">Aucun chien n’est actuellement disponible.</p>
+      <p id="no-dogs-message" class="hidden-message">Aucun chien n’est actuellement disponible.</p>
   </section>
   <script src="js/app.js"></script>
 </body>

--- a/d/index.html
+++ b/d/index.html
@@ -13,7 +13,7 @@
   <header>
     <div class="branding">
       <img src="images/logo.png" alt="Logo Mon Compagnon" class="logo">
-      <span style="font-size:1.4rem;font-weight:bold;">Mon&nbsp;Compagnon</span>
+        <span class="brand-title">Mon&nbsp;Compagnon</span>
     </div>
     <nav>
       <a href="index.html" class="active">Accueil</a>
@@ -36,7 +36,7 @@
     <h2 class="section-title">Chiens à adopter</h2>
     <a href="dogs.html" class="search-button">Chercher un chien</a>
     <div id="home-dogs-container" class="cards-container"></div>
-    <p id="no-home-dogs-message" style="text-align:center; display:none;">Aucun chien n’est actuellement disponible.</p>
+      <p id="no-home-dogs-message" class="hidden-message">Aucun chien n’est actuellement disponible.</p>
   </section>
   <section class="section">
     <h2 class="section-title">Chiens qui ont trouvé un nouveau foyer</h2>
@@ -85,7 +85,7 @@
     <p>Rejoignez‑nous dès aujourd’hui et offrez à votre fidèle ami un avenir serein et sécurisé.</p>
     <a href="signup.html" class="btn">Je m’abonne</a>
   </section>
-  <footer style="text-align:center; padding:1rem 0; background:#c16e33; color:#fff;">
+    <footer class="footer">
     &copy; <span id="year"></span> Mon&nbsp;Compagnon
   </footer>
   <script>

--- a/d/login.html
+++ b/d/login.html
@@ -10,7 +10,7 @@
   <header>
     <div class="branding">
       <img src="images/logo.png" alt="Logo Mon Compagnon" class="logo">
-      <span style="font-size:1.4rem;font-weight:bold;">Mon&nbsp;Compagnon</span>
+        <span class="brand-title">Mon&nbsp;Compagnon</span>
     </div>
     <nav>
       <a href="index.html">Accueil</a>
@@ -25,9 +25,9 @@
     <input type="email" id="login-email" required>
     <label for="login-password">Mot de passe</label>
     <input type="password" id="login-password" required>
-    <p id="login-error" style="color:red;"></p>
+      <p id="login-error" class="error-message"></p>
     <button type="submit">Connexion</button>
-    <p style="text-align:center;margin-top:1rem;">Pas encore de compte&nbsp;? <a href="signup.html">S'abonner</a></p>
+      <p class="form-note">Pas encore de compte&nbsp;? <a href="signup.html">S'abonner</a></p>
   </form>
   <script src="js/app.js"></script>
 </body>

--- a/d/signup.html
+++ b/d/signup.html
@@ -10,7 +10,7 @@
   <header>
     <div class="branding">
       <img src="images/logo.png" alt="Logo Mon Compagnon" class="logo">
-      <span style="font-size:1.4rem;font-weight:bold;">Mon&nbsp;Compagnon</span>
+        <span class="brand-title">Mon&nbsp;Compagnon</span>
     </div>
     <nav>
       <a href="index.html">Accueil</a>
@@ -30,9 +30,9 @@
     <!-- we avoid using the native required attribute here so we can
          display custom validation messages in the application script -->
     <input type="password" id="signup-confirm">
-    <p id="signup-error" style="color:red;"></p>
+      <p id="signup-error" class="error-message"></p>
     <button type="submit">S'abonner</button>
-    <p style="text-align:center;margin-top:1rem;">Déjà inscrit&nbsp;? <a href="login.html">Se connecter</a></p>
+      <p class="form-note">Déjà inscrit&nbsp;? <a href="login.html">Se connecter</a></p>
   </form>
   <script src="js/app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add brand title, error, note, hidden and footer classes in central stylesheet
- replace inline `style` attributes in HTML files with the new classes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ae9202f083288ff4f39c625231c4