### PR TITLE
style: add reusable error message styling

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -557,3 +557,34 @@ button:hover {
   font-weight: bold;
   color: var(--primary-color);
 }
+
+/* Generic styling for form validation errors */
+.form-error {
+  color: #b00020;
+  margin-top: 0.25rem;
+  font-size: 0.9rem;
+  font-style: italic;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  animation: fade-in 0.3s ease-in-out;
+}
+
+.form-error::before {
+  content: "⚠️";
+}
+
+.form-error:empty {
+  display: none;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/d/dashboard.html
+++ b/d/dashboard.html
@@ -42,7 +42,7 @@
         <input type="file" id="pet-vet" accept="application/pdf,image/*">
         <label for="pet-photos">Photos du chien (au moins deux)</label>
         <input type="file" id="pet-photos" accept="image/*" multiple>
-        <p id="pet-error" style="color:red;"></p>
+        <p id="pet-error" class="form-error"></p>
         <button type="submit">Enregistrer les informations</button>
       </form>
     </section>

--- a/d/login.html
+++ b/d/login.html
@@ -25,7 +25,7 @@
     <input type="email" id="login-email" required>
     <label for="login-password">Mot de passe</label>
     <input type="password" id="login-password" required>
-    <p id="login-error" style="color:red;"></p>
+    <p id="login-error" class="form-error"></p>
     <button type="submit">Connexion</button>
     <p style="text-align:center;margin-top:1rem;">Pas encore de compte&nbsp;? <a href="signup.html">S'abonner</a></p>
   </form>

--- a/d/signup.html
+++ b/d/signup.html
@@ -30,7 +30,7 @@
     <!-- we avoid using the native required attribute here so we can
          display custom validation messages in the application script -->
     <input type="password" id="signup-confirm">
-    <p id="signup-error" style="color:red;"></p>
+    <p id="signup-error" class="form-error"></p>
     <button type="submit">S'abonner</button>
     <p style="text-align:center;margin-top:1rem;">Déjà inscrit&nbsp;? <a href="login.html">Se connecter</a></p>
   </form>


### PR DESCRIPTION
## Summary
- add `.form-error` utility class for consistent, animated error messages
- replace inline error `<p>` styles in login, signup, and dashboard pages

## Testing
- `node - <<'NODE' ...` (verify login error display)
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0aea4ded48328affdcfa18886f5b6