### PR TITLE
Use shared header fragment across pages

### DIFF
--- a/d/dashboard.html
+++ b/d/dashboard.html
@@ -7,17 +7,7 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body id="dashboard-page">
-  <header>
-    <div class="branding">
-      <img src="images/logo.png" alt="Logo Mon Compagnon" class="logo">
-      <span style="font-size:1.4rem;font-weight:bold;">Mon&nbsp;Compagnon</span>
-    </div>
-    <nav>
-      <a href="index.html">Accueil</a>
-      <a href="dogs.html">Trouver un chien</a>
-      <a href="javascript:void(0)" id="logout-btn">Se déconnecter</a>
-    </nav>
-  </header>
+  <div id="header-placeholder"></div>
   <div class="dashboard">
     <h2>Bienvenue dans votre espace</h2>
     <p>Montant actuel de la cagnotte de votre chien&nbsp;: <strong id="fund-value">0&nbsp;€</strong></p>
@@ -55,6 +45,7 @@
       <div id="album-gallery" class="album-gallery"></div>
     </section>
   </div>
+  <script src="js/header.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/d/dogs.html
+++ b/d/dogs.html
@@ -7,18 +7,7 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body id="dogs-page">
-  <header>
-    <div class="branding">
-      <img src="images/logo.png" alt="Logo Mon Compagnon" class="logo">
-      <span style="font-size:1.4rem;font-weight:bold;">Mon&nbsp;Compagnon</span>
-    </div>
-    <nav>
-      <a href="index.html">Accueil</a>
-      <a href="login.html">Se connecter</a>
-      <a href="signup.html">S'abonner</a>
-      <a href="dogs.html">Trouver un chien</a>
-    </nav>
-  </header>
+  <div id="header-placeholder"></div>
   <section class="section">
     <h2 class="section-title">Chiens en recherche d’un nouveau foyer</h2>
     <div id="dogs-container" class="cards-container">
@@ -26,6 +15,7 @@
     </div>
     <p id="no-dogs-message" style="text-align:center; display:none;">Aucun chien n’est actuellement disponible.</p>
   </section>
+  <script src="js/header.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/d/header.html
+++ b/d/header.html
@@ -1,0 +1,12 @@
+<header>
+  <div class="branding">
+    <img src="images/logo.png" alt="Logo Mon Compagnon" class="logo">
+    <span style="font-size:1.4rem;font-weight:bold;">Mon&nbsp;Compagnon</span>
+  </div>
+  <nav>
+    <a href="index.html">Accueil</a>
+    <a href="login.html">Se connecter</a>
+    <a href="signup.html">S'abonner</a>
+    <a href="dogs.html">Trouver un chien</a>
+  </nav>
+</header>

--- a/d/index.html
+++ b/d/index.html
@@ -10,18 +10,7 @@
   <div class="awareness-banner">
     <span id="awareness-text"></span>
   </div>
-  <header>
-    <div class="branding">
-      <img src="images/logo.png" alt="Logo Mon Compagnon" class="logo">
-      <span style="font-size:1.4rem;font-weight:bold;">Mon&nbsp;Compagnon</span>
-    </div>
-    <nav>
-      <a href="index.html" class="active">Accueil</a>
-      <a href="login.html">Se connecter</a>
-      <a href="signup.html">S'abonner</a>
-      <a href="dogs.html">Trouver un chien</a>
-    </nav>
-  </header>
+  <div id="header-placeholder"></div>
   <div class="donation-banner">
     <span>Participez à notre cagnotte solidaire&nbsp;!</span>
     <a href="#" class="donate-button">Je fais un don</a>
@@ -91,6 +80,7 @@
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
+  <script src="js/header.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/d/js/header.js
+++ b/d/js/header.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const placeholder = document.getElementById('header-placeholder');
+  if (!placeholder) return;
+  fetch('header.html')
+    .then(res => res.text())
+    .then(html => {
+      placeholder.innerHTML = html;
+      const current = window.location.pathname.split('/').pop();
+      const active = placeholder.querySelector(`nav a[href="${current}"]`);
+      if (active) {
+        active.classList.add('active');
+      }
+    })
+    .catch(err => console.error('Erreur lors du chargement du header:', err));
+});

--- a/d/login.html
+++ b/d/login.html
@@ -7,18 +7,7 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <header>
-    <div class="branding">
-      <img src="images/logo.png" alt="Logo Mon Compagnon" class="logo">
-      <span style="font-size:1.4rem;font-weight:bold;">Mon&nbsp;Compagnon</span>
-    </div>
-    <nav>
-      <a href="index.html">Accueil</a>
-      <a href="login.html">Se connecter</a>
-      <a href="signup.html">S'abonner</a>
-      <a href="dogs.html">Trouver un chien</a>
-    </nav>
-  </header>
+  <div id="header-placeholder"></div>
   <form id="login-form">
     <h2>Se connecter</h2>
     <label for="login-email">Adresse e‑mail</label>
@@ -29,6 +18,7 @@
     <button type="submit">Connexion</button>
     <p style="text-align:center;margin-top:1rem;">Pas encore de compte&nbsp;? <a href="signup.html">S'abonner</a></p>
   </form>
+  <script src="js/header.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/d/signup.html
+++ b/d/signup.html
@@ -7,18 +7,7 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <header>
-    <div class="branding">
-      <img src="images/logo.png" alt="Logo Mon Compagnon" class="logo">
-      <span style="font-size:1.4rem;font-weight:bold;">Mon&nbsp;Compagnon</span>
-    </div>
-    <nav>
-      <a href="index.html">Accueil</a>
-      <a href="login.html">Se connecter</a>
-      <a href="signup.html">S'abonner</a>
-      <a href="dogs.html">Trouver un chien</a>
-    </nav>
-  </header>
+  <div id="header-placeholder"></div>
   <form id="signup-form">
     <h2>Créer un compte</h2>
     <p>Abonnement mensuel&nbsp;: <strong>6&nbsp;€</strong> (dont 4&nbsp;€ versés à la cagnotte de votre chien)</p>
@@ -34,6 +23,7 @@
     <button type="submit">S'abonner</button>
     <p style="text-align:center;margin-top:1rem;">Déjà inscrit&nbsp;? <a href="login.html">Se connecter</a></p>
   </form>
+  <script src="js/header.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract common header into `header.html`
- load header fragment on each page via `header.js`
- replace duplicated header markup with placeholder in site pages

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a0ae9fc61083289fb65e13e04173c1