### PR TITLE
feat: add bulk photo download

### DIFF
--- a/d/dashboard.html
+++ b/d/dashboard.html
@@ -53,8 +53,10 @@
       <h3>Album photo de votre chien</h3>
       <input type="file" id="album-input" accept="image/*" multiple>
       <div id="album-gallery" class="album-gallery"></div>
+      <button type="button" id="download-photos" class="download-btn">Télécharger toutes les photos</button>
     </section>
   </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/d/js/app.js
+++ b/d/js/app.js
@@ -319,11 +319,15 @@ function displayPetInfo(pet) {
 function initAlbum(user) {
   const section = document.getElementById('photo-album');
   const input = document.getElementById('album-input');
+  const downloadBtn = document.getElementById('download-photos');
   if (!section || !input) return;
   section.style.display = 'block';
   displayAlbum(user.pet);
   if (input.dataset.initialized) return;
   input.dataset.initialized = 'true';
+  if (downloadBtn) {
+    downloadBtn.addEventListener('click', () => downloadAllPhotos(user.pet));
+  }
   input.addEventListener('change', () => {
     const files = Array.from(input.files);
     if (files.length === 0) return;
@@ -364,7 +368,7 @@ function displayAlbum(pet) {
       img.style.cursor = 'pointer';
       const link = document.createElement('a');
       link.href = ph.data;
-      link.target = '_blank';
+      link.download = ph.name || `photo_${index + 1}`;
       link.appendChild(img);
       wrap.appendChild(link);
       const ta = document.createElement('textarea');
@@ -384,6 +388,23 @@ function displayAlbum(pet) {
       gallery.appendChild(wrap);
     });
   }
+}
+
+function downloadAllPhotos(pet) {
+  if (!pet.photos || pet.photos.length === 0) return;
+  const zip = new JSZip();
+  pet.photos.forEach((ph, index) => {
+    const base64 = ph.data.split(',')[1];
+    const name = ph.name || `photo_${index + 1}.png`;
+    zip.file(name, base64, { base64: true });
+  });
+  zip.generateAsync({ type: 'blob' }).then(content => {
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(content);
+    link.download = 'photos_chien.zip';
+    link.click();
+    setTimeout(() => URL.revokeObjectURL(link.href), 1000);
+  });
 }
 
 // Display all dogs for adoption on dogs.html


### PR DESCRIPTION
## Summary
- allow dashboard users to download all stored photos at once
- add JSZip dependency and download button on dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b089f5088328a52e2ce3c3a698cc