### PR TITLE
Allow adding photos to album via import button

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -47,6 +47,10 @@ body {
   display: none;
 }
 
+.hidden-input {
+  display: none;
+}
+
 .footer {
   text-align: center;
   padding: 1rem 0;

--- a/d/dashboard.html
+++ b/d/dashboard.html
@@ -51,12 +51,11 @@
     </section>
       <section id="photo-album" class="hidden-section">
       <h3>Album photo de votre chien</h3>
-      <input type="file" id="album-input" accept="image/*" multiple>
+      <input type="file" id="album-input" accept="image/*" multiple class="hidden-input">
+      <button type="button" id="add-photos">Importer des photos</button>
       <div id="album-gallery" class="album-gallery"></div>
-      <button type="button" id="download-photos" class="download-btn">Télécharger toutes les photos</button>
     </section>
   </div>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/d/js/app.js
+++ b/d/js/app.js
@@ -319,14 +319,14 @@ function displayPetInfo(pet) {
 function initAlbum(user) {
   const section = document.getElementById('photo-album');
   const input = document.getElementById('album-input');
-  const downloadBtn = document.getElementById('download-photos');
+  const addBtn = document.getElementById('add-photos');
   if (!section || !input) return;
   section.style.display = 'block';
   displayAlbum(user.pet);
   if (input.dataset.initialized) return;
   input.dataset.initialized = 'true';
-  if (downloadBtn) {
-    downloadBtn.addEventListener('click', () => downloadAllPhotos(user.pet));
+  if (addBtn) {
+    addBtn.addEventListener('click', () => input.click());
   }
   input.addEventListener('change', () => {
     const files = Array.from(input.files);
@@ -368,7 +368,7 @@ function displayAlbum(pet) {
       img.style.cursor = 'pointer';
       const link = document.createElement('a');
       link.href = ph.data;
-      link.download = ph.name || `photo_${index + 1}`;
+      link.target = '_blank';
       link.appendChild(img);
       wrap.appendChild(link);
       const ta = document.createElement('textarea');
@@ -388,23 +388,6 @@ function displayAlbum(pet) {
       gallery.appendChild(wrap);
     });
   }
-}
-
-function downloadAllPhotos(pet) {
-  if (!pet.photos || pet.photos.length === 0) return;
-  const zip = new JSZip();
-  pet.photos.forEach((ph, index) => {
-    const base64 = ph.data.split(',')[1];
-    const name = ph.name || `photo_${index + 1}.png`;
-    zip.file(name, base64, { base64: true });
-  });
-  zip.generateAsync({ type: 'blob' }).then(content => {
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(content);
-    link.download = 'photos_chien.zip';
-    link.click();
-    setTimeout(() => URL.revokeObjectURL(link.href), 1000);
-  });
 }
 
 // Display all dogs for adoption on dogs.html


### PR DESCRIPTION
## Summary
- replace bulk download with a dedicated "Importer des photos" button
- hide file input and style via `.hidden-input`
- adjust album script to trigger file dialog and open images in new tab

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b25f6f2483288df9baec3b193aef