### PR TITLE
Align search button with adoption header

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -63,10 +63,9 @@ body {
 }
 
 .search-button {
-  display: block;
-  margin: 0 auto 1rem;
+  display: inline-block;
+  margin: 0;
   padding: 0.7rem 1.2rem;
-  max-width: 200px;
   text-align: center;
   background-color: var(--primary-color);
   color: #fff;
@@ -77,6 +76,24 @@ body {
 
 .search-button:hover {
   background-color: var(--secondary-color);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.section-header .section-title {
+  text-align: left;
+  margin: 0;
+}
+
+.section-header .search-button {
+  margin: 0;
 }
 
 /* Thin rotating awareness messages at the very top */

--- a/d/index.html
+++ b/d/index.html
@@ -33,8 +33,10 @@
     </div>
   </section>
   <section class="section">
-    <h2 class="section-title">Chiens à adopter</h2>
-    <a href="dogs.html" class="search-button">Chercher un chien</a>
+    <div class="section-header">
+      <h2 class="section-title">Chiens à adopter</h2>
+      <a href="dogs.html" class="search-button">Chercher un chien</a>
+    </div>
     <div id="home-dogs-container" class="cards-container"></div>
       <p id="no-home-dogs-message" class="hidden-message">Aucun chien n’est actuellement disponible.</p>
   </section>


### PR DESCRIPTION
## Summary
- Align "Chercher un chien" button beside the "Chiens à adopter" heading to save vertical space.
- Introduce responsive flex-based section header styling.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b2d846b48328ae13c0ff39c03079