### PR TITLE
Display uploaded photos with comment fields

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -454,6 +454,7 @@ button:hover {
   padding: 0.5rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 200px; /* ensure consistent width so items align side by side */
 }
 
 .album-comment {

--- a/d/js/app.js
+++ b/d/js/app.js
@@ -350,8 +350,9 @@ function initAlbum(user) {
     const tasks = files.map(file => new Promise(resolve => {
       const fr = new FileReader();
       fr.onload = () => {
-        const comment = prompt('Ajouter un commentaire pour cette photo :', '');
-        newPhotos.push({ name: file.name, data: fr.result, comment });
+        // Add the photo with an empty comment field. The textarea below the
+        // picture lets the user provide or edit a comment after import.
+        newPhotos.push({ name: file.name, data: fr.result, comment: '' });
         resolve();
       };
       fr.readAsDataURL(file);


### PR DESCRIPTION
## Summary
- Show newly imported photos directly in the album with editable comment text areas
- Ensure album items keep a consistent width so photos align side by side

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c39347ac832893205887bda2f251