### PR TITLE
feat: show additional pet photos in gallery

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -667,6 +667,20 @@ button:hover {
   font-size: 1.1rem;
 }
 
+.pet-extra-photos {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.pet-extra-photos img {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+}
+
 .pet-info h2 {
   text-align: center;
   color: var(--primary-color);

--- a/d/js/app.js
+++ b/d/js/app.js
@@ -314,6 +314,19 @@ function displayPetInfo(pet) {
   cardContent.appendChild(editBtn);
   card.appendChild(cardContent);
   infoEl.appendChild(card);
+
+  // Display additional photos below the card
+  if (pet.photos && pet.photos.length > 1) {
+    const extraContainer = document.createElement('div');
+    extraContainer.className = 'pet-extra-photos';
+    pet.photos.slice(1).forEach((photo) => {
+      const extraImg = document.createElement('img');
+      extraImg.src = photo.data;
+      extraImg.alt = pet.name;
+      extraContainer.appendChild(extraImg);
+    });
+    infoEl.appendChild(extraContainer);
+  }
 }
 
 // Initialize and manage the photo album section on the dashboard


### PR DESCRIPTION
## Summary
- render supplementary pet photos beneath main card
- style extra photo container for small thumbnails

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c68d254083289c304a084da8adc8