### PR TITLE
feat: improve extra pet photos display

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -668,10 +668,10 @@ button:hover {
 }
 
 .pet-extra-photos {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
   gap: 0.5rem;
-  justify-content: center;
+  justify-items: center;
   margin-top: 1rem;
 }
 
@@ -679,6 +679,7 @@ button:hover {
   width: 80px;
   height: 80px;
   object-fit: cover;
+  border-radius: 4px;
 }
 
 .pet-info h2 {

--- a/d/js/app.js
+++ b/d/js/app.js
@@ -318,11 +318,12 @@ function displayPetInfo(pet) {
   // Display additional photos below the card
   if (pet.photos && pet.photos.length > 1) {
     const extraContainer = document.createElement('div');
-    extraContainer.className = 'pet-extra-photos';
+    extraContainer.classList.add('pet-extra-photos');
     pet.photos.slice(1).forEach((photo) => {
       const extraImg = document.createElement('img');
       extraImg.src = photo.data;
       extraImg.alt = pet.name;
+      extraImg.loading = 'lazy';
       extraContainer.appendChild(extraImg);
     });
     infoEl.appendChild(extraContainer);


### PR DESCRIPTION
## Summary
- load additional pet photos lazily and show them below the main card
- style extra photos in a responsive grid with rounded thumbnails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cc2b1f1c83288ac46bd20f9bbc5a