### PR TITLE
Allow optional dog profile fields

### DIFF
--- a/d/js/app.js
+++ b/d/js/app.js
@@ -164,16 +164,8 @@ function savePetInfo(user) {
   const photoInput = document.getElementById('pet-photos');
   const errorEl = document.getElementById('pet-error');
   if (errorEl) errorEl.textContent = '';
-  if (!name || !breed || !dob || !desc || !food || !toy || !behavior) {
-    if (errorEl) errorEl.textContent = 'Veuillez remplir tous les champs concernant votre chien.';
-    return;
-  }
+  // Allow saving even if some fields are left empty or no photos are provided
   const existingPhotos = (user.pet && user.pet.photos) ? user.pet.photos : [];
-  const totalPhotos = existingPhotos.length + (photoInput.files ? photoInput.files.length : 0);
-  if (totalPhotos < 2) {
-    if (errorEl) errorEl.textContent = 'Veuillez ajouter au moins deux photos de votre chien.';
-    return;
-  }
   // Read files asynchronously and then save
   const readerTasks = [];
   // Vet certificate (single file)


### PR DESCRIPTION
## Summary
- Allow saving dog profile even with missing fields or photos

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68adf27d3a5483289846018151212388