### PR TITLE
Refine homepage banner layout

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -105,7 +105,7 @@ body {
   background-color: #ffe08a;
   color: #333;
   text-align: center;
-  padding: 0.3rem 0.5rem;
+  padding: 0.8rem 0.5rem;
   font-size: 0.85rem;
 }
 
@@ -119,7 +119,7 @@ body {
   gap: 1rem;
   padding: 0.5rem 1rem;
   font-size: 0.95rem;
-  margin: 2rem 0;
+  margin: 2rem 0 0;
 }
 
 .donation-banner .donate-button {


### PR DESCRIPTION
## Summary
- Thicken the alert banner at the top of the home page
- Remove extra spacing before the footer by adjusting the donation banner margin

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68adf33149d48328a9a1aa87b3e8e68c