### PR TITLE
Make all form fields optional

### DIFF
--- a/d/dashboard.html
+++ b/d/dashboard.html
@@ -25,19 +25,19 @@
       <h3>Décrivez votre animal</h3>
       <form id="pet-form">
         <label for="pet-name">Nom du chien</label>
-        <input type="text" id="pet-name" required>
+          <input type="text" id="pet-name">
         <label for="pet-breed">Race</label>
-        <input type="text" id="pet-breed" required>
+          <input type="text" id="pet-breed">
         <label for="pet-dob">Date de naissance</label>
-        <input type="date" id="pet-dob" required>
+          <input type="date" id="pet-dob">
         <label for="pet-desc">Description</label>
-        <textarea id="pet-desc" placeholder="Décrivez le caractère, l’âge et les besoins de votre chien" required></textarea>
+          <textarea id="pet-desc" placeholder="Décrivez le caractère, l’âge et les besoins de votre chien"></textarea>
         <label for="pet-food">Aliment préféré</label>
-        <input type="text" id="pet-food" required>
+          <input type="text" id="pet-food">
         <label for="pet-toy">Jouet préféré</label>
-        <input type="text" id="pet-toy" required>
+          <input type="text" id="pet-toy">
         <label for="pet-behavior">Comportement</label>
-        <textarea id="pet-behavior" placeholder="Décrivez les habitudes et le tempérament" required></textarea>
+          <textarea id="pet-behavior" placeholder="Décrivez les habitudes et le tempérament"></textarea>
         <label for="pet-vet">Certificat vétérinaire de santé</label>
         <input type="file" id="pet-vet" accept="application/pdf,image/*">
         <label for="pet-photos">Photos du chien (au moins deux)</label>

--- a/d/login.html
+++ b/d/login.html
@@ -22,9 +22,9 @@
   <form id="login-form">
     <h2>Se connecter</h2>
     <label for="login-email">Adresse e‑mail</label>
-    <input type="email" id="login-email" required>
+      <input type="email" id="login-email">
     <label for="login-password">Mot de passe</label>
-    <input type="password" id="login-password" required>
+      <input type="password" id="login-password">
       <p id="login-error" class="error-message"></p>
     <button type="submit">Connexion</button>
       <p class="form-note">Pas encore de compte&nbsp;? <a href="signup.html">S'abonner</a></p>

--- a/d/signup.html
+++ b/d/signup.html
@@ -23,9 +23,9 @@
     <h2>Créer un compte</h2>
     <p>Abonnement mensuel&nbsp;: <strong>6&nbsp;€</strong> (dont 4&nbsp;€ versés à la cagnotte de votre chien)</p>
     <label for="signup-email">Adresse e‑mail</label>
-    <input type="email" id="signup-email" required>
+      <input type="email" id="signup-email">
     <label for="signup-password">Mot de passe</label>
-    <input type="password" id="signup-password" required>
+      <input type="password" id="signup-password">
     <label for="signup-confirm">Confirmez le mot de passe</label>
     <!-- we avoid using the native required attribute here so we can
          display custom validation messages in the application script -->


### PR DESCRIPTION
## Summary
- Remove `required` attributes from login form inputs
- Remove `required` attributes from signup form inputs
- Allow pet profile form inputs and textareas to be optional

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68adf6eb44c08328901b6328806dec08