### PR TITLE
Afficher fiche descriptive du chien après enregistrement

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -400,6 +400,9 @@ button:hover {
 .pet-info {
   margin-top: 1rem;
   display: none;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
 }
 
 .pet-info button {

--- a/d/js/app.js
+++ b/d/js/app.js
@@ -241,7 +241,7 @@ function displayPetInfo(pet) {
   if (!infoEl) return;
   const form = document.getElementById('pet-form');
   if (form) form.style.display = 'none';
-  infoEl.style.display = 'block';
+  infoEl.style.display = 'flex';
   // Clear existing
   infoEl.innerHTML = '';
   const title = document.createElement('h2');
@@ -301,7 +301,8 @@ function displayPetInfo(pet) {
   cardContent.appendChild(editBtn);
   card.appendChild(cardContent);
   infoEl.appendChild(card);
-
+  // ensure the newly created sheet is visible
+  window.scrollTo({ top: infoEl.offsetTop, behavior: 'smooth' });
 }
 
 // Show detailed information about a dog in a modal


### PR DESCRIPTION
## Summary
- Améliore le style de la fiche descriptive de l'animal en centrant le contenu et en ajoutant un espacement.
- Affiche la fiche du chien en mode flex et fait défiler la page vers celle-ci après enregistrement.

## Testing
- `npm test` *(échoue : Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68adf9ae12dc83288f03e900ce4e9ebf