### PR TITLE
Allow multiple photos for user pets

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -656,3 +656,24 @@ button:hover {
   font-size: 1.5rem;
   cursor: pointer;
 }
+
+/* Gallery of additional pet photos on the dashboard */
+.photo-gallery {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.photo-gallery img {
+  width: 120px;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.photo-gallery figcaption {
+  text-align: center;
+  font-size: 0.8rem;
+  margin-top: 0.2rem;
+}

--- a/d/dashboard.html
+++ b/d/dashboard.html
@@ -40,8 +40,8 @@
           <textarea id="pet-behavior" placeholder="Décrivez les habitudes et le tempérament"></textarea>
         <label for="pet-vet">Certificat vétérinaire de santé</label>
         <input type="file" id="pet-vet" accept="application/pdf,image/*">
-        <label for="pet-photos">Photo du chien</label>
-        <input type="file" id="pet-photos" accept="image/*">
+        <label for="pet-photos">Photos du chien</label>
+        <input type="file" id="pet-photos" accept="image/*" multiple>
           <p id="pet-error" class="error-message"></p>
         <button type="submit">Enregistrer les informations</button>
       </form>

--- a/d/js/app.js
+++ b/d/js/app.js
@@ -213,8 +213,9 @@ function savePetInfo(user) {
   const photoInput = document.getElementById('pet-photos');
   const errorEl = document.getElementById('pet-error');
   if (errorEl) errorEl.textContent = '';
-  // Allow saving even if some fields are left empty or no photos are provided
-  const existingPhoto = (user.pet && user.pet.photos && user.pet.photos[0]) ? user.pet.photos[0] : null;
+  // Preserve existing photos if any
+  const existingPhotos = (user.pet && user.pet.photos) ? user.pet.photos : [];
+  const newPhotos = [...existingPhotos];
   // Read files asynchronously and then save
   const readerTasks = [];
   // Vet certificate (single file)
@@ -231,20 +232,20 @@ function savePetInfo(user) {
     });
     readerTasks.push(vetPromise);
   }
-  // Photo (single)
-  let photoObj = existingPhoto;
+  // Photos (multiple)
   if (photoInput.files && photoInput.files.length > 0) {
-    const file = photoInput.files[0];
-    const p = new Promise((resolve) => {
-      const fr = new FileReader();
-      fr.onload = function() {
-        const comment = prompt('Ajouter un commentaire pour cette photo :', '');
-        photoObj = { name: file.name, data: fr.result, comment };
-        resolve();
-      };
-      fr.readAsDataURL(file);
+    Array.from(photoInput.files).forEach(file => {
+      const p = new Promise((resolve) => {
+        const fr = new FileReader();
+        fr.onload = function() {
+          const comment = prompt('Ajouter un commentaire pour cette photo :', '');
+          newPhotos.push({ name: file.name, data: fr.result, comment });
+          resolve();
+        };
+        fr.readAsDataURL(file);
+      });
+      readerTasks.push(p);
     });
-    readerTasks.push(p);
   }
   Promise.all(readerTasks).then(() => {
     const users = getUsers();
@@ -259,13 +260,14 @@ function savePetInfo(user) {
       toy,
       behavior,
       vetFile: vetObj,
-      photos: photoObj ? [photoObj] : []
+      photos: newPhotos
     };
     users[idx].pet = petObj;
     setUsers(users);
     user.pet = petObj;
     notifySeekers(petObj);
     displayPetInfo(petObj);
+    if (photoInput) photoInput.value = '';
   });
 }
 
@@ -354,6 +356,28 @@ function displayPetInfo(pet) {
   cardContent.appendChild(editBtn);
   card.appendChild(cardContent);
   infoEl.appendChild(card);
+  // Photo gallery below the card
+  if (pet.photos && pet.photos.length > 0) {
+    const galleryTitle = document.createElement('h3');
+    galleryTitle.textContent = 'Galerie de photos';
+    infoEl.appendChild(galleryTitle);
+    const gallery = document.createElement('div');
+    gallery.className = 'photo-gallery';
+    pet.photos.forEach(photo => {
+      const fig = document.createElement('figure');
+      const imgEl = document.createElement('img');
+      imgEl.src = photo.data;
+      imgEl.alt = photo.name;
+      fig.appendChild(imgEl);
+      if (photo.comment) {
+        const cap = document.createElement('figcaption');
+        cap.textContent = photo.comment;
+        fig.appendChild(cap);
+      }
+      gallery.appendChild(fig);
+    });
+    infoEl.appendChild(gallery);
+  }
   // ensure the newly created sheet is visible
   window.scrollTo({ top: infoEl.offsetTop, behavior: 'smooth' });
 }


### PR DESCRIPTION
## Summary
- Allow uploading multiple photos for each dog via dashboard
- Display photo gallery beneath pet profile
- Style gallery for neat multi-image layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68adfede7eac8328b0d4c3aeb61228b4