### PR TITLE
Remove comment prompt for animal photos

### DIFF
--- a/d/js/app.js
+++ b/d/js/app.js
@@ -243,8 +243,7 @@ function savePetInfo(user) {
       const p = new Promise((resolve) => {
         const fr = new FileReader();
         fr.onload = function() {
-          const comment = prompt('Ajouter un commentaire pour cette photo :', '');
-          newPhotos.push({ name: file.name, data: fr.result, comment });
+          newPhotos.push({ name: file.name, data: fr.result });
           resolve();
         };
         fr.readAsDataURL(file);
@@ -386,11 +385,6 @@ function displayPetInfo(pet) {
       imgEl.src = photo.data;
       imgEl.alt = photo.name;
       fig.appendChild(imgEl);
-      if (photo.comment) {
-        const cap = document.createElement('figcaption');
-        cap.textContent = photo.comment;
-        fig.appendChild(cap);
-      }
       gallery.appendChild(fig);
     });
     infoEl.appendChild(gallery);


### PR DESCRIPTION
## Summary
- Stop prompting for photo comments when adding animal entries
- Drop photo caption rendering to avoid unnecessary comment field

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ae2eb90b4483288393e374d0ee6b8f