### PR TITLE
Enable unlimited pet photo uploads with comments

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -751,3 +751,7 @@ button:hover {
   font-size: 0.8rem;
   margin-top: 0.2rem;
 }
+
+.add-photo {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- Allow users to upload additional pet photos after the profile is displayed
- Prompt for a comment on each uploaded photo and store it in the gallery
- Add basic styling for the photo upload section

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2eec72548328b39beee7d85abe44