### PR TITLE
Ajouter validation lors de l’enregistrement de la fiche chien

### DIFF
--- a/d/js/app.js
+++ b/d/js/app.js
@@ -218,6 +218,10 @@ function savePetInfo(user) {
   const photoInput = document.getElementById('pet-photos');
   const errorEl = document.getElementById('pet-error');
   if (errorEl) errorEl.textContent = '';
+  if (!name || !desc) {
+    if (errorEl) errorEl.textContent = 'Veuillez renseigner au moins le nom et la description.';
+    return;
+  }
   // Preserve existing photos if any
   const existingPhotos = (user.pet && user.pet.photos) ? user.pet.photos : [];
   const newPhotos = [...existingPhotos];
@@ -255,6 +259,10 @@ function savePetInfo(user) {
     const users = getUsers();
     // Update this user
     const idx = users.findIndex(u => u.email === user.email);
+    if (idx === -1) {
+      if (errorEl) errorEl.textContent = "Utilisateur introuvable. Veuillez vous reconnecter.";
+      return;
+    }
     const petObj = {
       name,
       breed,


### PR DESCRIPTION
## Résumé
- Vérifie que le nom et la description du chien sont renseignés avant la sauvegarde de la fiche.
- Affiche un message d’erreur si l’utilisateur courant est introuvable lors de la sauvegarde.

## Tests
- `npm test` (échoue: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ae3336e9088328992a7785c2383637