### PR TITLE
Fix dog cards cut off on homepage

### DIFF
--- a/d/css/style.css
+++ b/d/css/style.css
@@ -528,6 +528,7 @@ button:hover {
 #home-dogs-container {
   flex-wrap: nowrap;
   overflow-x: auto;
+  justify-content: flex-start;
 }
 
 #home-dogs-container .card {


### PR DESCRIPTION
## Summary
- Ensure home page dog cards align to the left so they are fully visible

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae33af2fac8328a4cf7908ce4c2c02