### PR TITLE
Hide pet form after saving

### DIFF
--- a/d/js/app.js
+++ b/d/js/app.js
@@ -167,7 +167,11 @@ function loadDashboard() {
     const infoSection = document.getElementById('pet-info');
     if (infoSection) infoSection.style.display = 'none';
     const formEl = document.getElementById('pet-form');
-    if (formEl) formEl.style.display = 'block';
+    if (formEl) {
+      formEl.style.display = 'block';
+      const formSection = formEl.closest('section');
+      if (formSection) formSection.style.display = 'block';
+    }
   }
   // Attach form handler
   const petForm = document.getElementById('pet-form');
@@ -290,6 +294,8 @@ function showEditForm(pet) {
   const infoEl = document.getElementById('pet-info');
   if (infoEl) infoEl.style.display = 'none';
   if (form) {
+    const formSection = form.closest('section');
+    if (formSection) formSection.style.display = 'block';
     form.style.display = 'block';
     if (pet) {
       document.getElementById('pet-name').value = pet.name || '';
@@ -309,7 +315,11 @@ function displayPetInfo(pet) {
   const infoEl = document.getElementById('pet-info');
   if (!infoEl) return;
   const form = document.getElementById('pet-form');
-  if (form) form.style.display = 'none';
+  if (form) {
+    form.style.display = 'none';
+    const formSection = form.closest('section');
+    if (formSection) formSection.style.display = 'none';
+  }
   infoEl.style.display = 'flex';
   // Clear existing
   infoEl.innerHTML = '';


### PR DESCRIPTION
## Summary
- Hide the entire dashboard form section once pet info is saved and show it again when editing
- Ensure form section is revealed when no pet data exists on dashboard load

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae386d42a883288df388480e608f2e